### PR TITLE
Out2vtk

### DIFF
--- a/dnsdata.f90
+++ b/dnsdata.f90
@@ -142,7 +142,7 @@ logical::rtd_exists ! flag to check existence of Runtimedata
     ibeta=(/(dcmplx(0.0d0,iz*beta0),iz=-nz,nz)/); 
     FORALL  (iz=-nz:nz,ix=nx0:nxN) k2(iz,ix)=(alfa0*ix)**2.0d0+(beta0*iz)**2.0d0
     INQUIRE(FILE="Runtimedata", EXIST=rtd_exists)
-    IF (has_terminal) THEN
+    IF (solveNS .AND. has_terminal) THEN
       IF (time_from_restart .AND. rtd_exists) THEN
         WRITE(*,*) 'Found existing Runtimedata...'
         OPEN(UNIT=101,FILE='Runtimedata',ACTION='readwrite')
@@ -207,8 +207,10 @@ logical::rtd_exists ! flag to check existence of Runtimedata
   SUBROUTINE free_memory(solveNS)
     LOGICAL, intent(IN) :: solveNS
     DEALLOCATE(V,der,d0mat,etamat,D2vmat,y,dy)
-    IF (solveNS) DEALLOCATE(memrhs,oldrhs,bc0,bcn)
-    IF (has_terminal) CLOSE(UNIT=101)
+    IF (solveNS) THEN
+      DEALLOCATE(memrhs,oldrhs,bc0,bcn)
+      IF (has_terminal) CLOSE(UNIT=101)
+    END IF
   END SUBROUTINE free_memory
 
   !--------------------------------------------------------------!

--- a/ffts.f90
+++ b/ffts.f90
@@ -49,7 +49,6 @@ CONTAINS
        ! meaning that by default the logical size of the real transform is even
        if (odd_n_real==.TRUE.) rn_x=rn_x - 1
      endif
-     print *, "rn_x", rn_x
      !Allocate aligned memory
      ptrVVdz=fftw_alloc_complex(int(nxB*nzd*6*6, C_SIZE_T))
      ptrVVdx=fftw_alloc_complex(int((nxd+1)*nzB*6*6, C_SIZE_T))

--- a/ffts.f90
+++ b/ffts.f90
@@ -30,19 +30,26 @@ MODULE ffts
 CONTAINS
 
 #ifdef ibm
-   SUBROUTINE init_fft(VVdz,VVdx,rVVdx,Fdz,Fdx,rFdx,nxd,nxB,nzd,nzB)
+   SUBROUTINE init_fft(VVdz,VVdx,rVVdx,Fdz,Fdx,rFdx,nxd,nxB,nzd,nzB,odd_n_real)
 #else
-   SUBROUTINE init_fft(VVdz,VVdx,rVVdx,nxd,nxB,nzd,nzB)
+   SUBROUTINE init_fft(VVdz,VVdx,rVVdx,nxd,nxB,nzd,nzB,odd_n_real)
 #endif
      integer(C_INT), intent(in) :: nxd,nxB,nzd,nzB
      complex(C_DOUBLE_COMPLEX), pointer, dimension(:,:,:,:), intent(out) :: VVdx, VVdz
      real(C_DOUBLE), pointer, dimension(:,:,:,:), intent(out) :: rVVdx
+     logical, optional, intent(in) :: odd_n_real
 #ifdef ibm
      complex(C_DOUBLE_COMPLEX), pointer, dimension(:,:,:,:), intent(out) :: Fdx, Fdz
      real(C_DOUBLE), pointer, dimension(:,:,:,:), intent(out) :: rFdx
 #endif
      integer(C_INT), dimension(1) :: n_z, n_x, rn_x
      n_z=[nzd]; n_x=[nxd]; rn_x=[2*nxd];
+     if (present(odd_n_real)) then
+       ! notice: odd_n_real is basically .FALSE. by default
+       ! meaning that by default the logical size of the real transform is even
+       if (odd_n_real==.TRUE.) rn_x=rn_x - 1
+     endif
+     print *, "rn_x", rn_x
      !Allocate aligned memory
      ptrVVdz=fftw_alloc_complex(int(nxB*nzd*6*6, C_SIZE_T))
      ptrVVdx=fftw_alloc_complex(int((nxd+1)*nzB*6*6, C_SIZE_T))
@@ -61,8 +68,8 @@ CONTAINS
      pFFT=fftw_plan_many_dft(1, n_z, nxB, VVdz(:,:,1,1), n_z, 1, nzd, VVdz(:,:,1,1), n_z, 1, nzd, FFTW_FORWARD,  plan_type)
      pIFT=fftw_plan_many_dft(1, n_z, nxB, VVdz(:,:,1,1), n_z, 1, nzd, VVdz(:,:,1,1), n_z, 1, nzd, FFTW_BACKWARD, plan_type)
      pRFT=fftw_plan_many_dft_c2r(1, rn_x, nzB,  VVdx(:,:,1,1),  n_x+1, 1,   (nxd+1), &
-                                               rVVdx(:,:,1,1), rn_x+2, 1, 2*(nxd+1), plan_type)
-     pHFT=fftw_plan_many_dft_r2c(1, rn_x, nzB, rVVdx(:,:,1,1), rn_x+2, 1, 2*(nxd+1), &
+                                               rVVdx(:,:,1,1), 2*(n_x+1), 1, 2*(nxd+1), plan_type)
+     pHFT=fftw_plan_many_dft_r2c(1, rn_x, nzB, rVVdx(:,:,1,1), 2*(n_x+1), 1, 2*(nxd+1), &
                                                 VVdx(:,:,1,1),  n_x+1, 1,   (nxd+1), plan_type)
    END SUBROUTINE init_fft
 

--- a/out2vtk.f90
+++ b/out2vtk.f90
@@ -403,7 +403,7 @@ contains !----------------------------------------------------------------------
         xprj = (xx - 1.0) / (nxtot-1.0) * (2*nx) + 1
         zprj = (zz - 1.0) / (nztot-1.0) * (2*nz) + 1
 
-    end function undersampled_to_fullindex
+    end subroutine undersampled_to_fullindex
 
 
 

--- a/out2vtk.f90
+++ b/out2vtk.f90
@@ -426,8 +426,8 @@ contains !----------------------------------------------------------------------
     integer, intent(in) :: xx, zz
     real, intent(out) :: xprj,zprj
 
-        xprj = (2*nx+1)/(nxtot) * (xx - 1.0) + 1
-        zprj = (2*nz+1)/(nztot) * (zz - 1.0) + 1
+        xprj = real(2*nx+1)/real(nxtot) * (xx - 1.0) + 1
+        zprj = real(2*nz+1)/real(nztot) * (zz - 1.0) + 1
 
     end subroutine undersampled_to_fullindex
 

--- a/out2vtk.f90
+++ b/out2vtk.f90
@@ -71,7 +71,7 @@ type(MPI_Datatype) :: wtype_3d, type_towrite ! , wtype_scalar
     ! notice that this overrides value from dns.in
 
     call init_MPI(nx+1,nz,ny,nxd+1,nzd)
-    call init_memory(.TRUE.)
+    call init_memory(.FALSE.)
     call init_fft(VVdz,VVdx,rVVdx,nxB,nxB,2*nz+1,2*nz+1)
     ! Notice that in the call to init_fft the values of nxd and nzd have been replaced by nxB and 2*nz+1.
     ! Since the parallelisation in xz is deactivated, nxB=nx+1.
@@ -217,7 +217,7 @@ type(MPI_Datatype) :: wtype_3d, type_towrite ! , wtype_scalar
 
     ! realease memory
     CALL free_fft()
-    CALL free_memory(.TRUE.) 
+    CALL free_memory(.FALSE.) 
     CALL MPI_Finalize()
 
 

--- a/out2vtk.f90
+++ b/out2vtk.f90
@@ -64,15 +64,22 @@ type(MPI_Datatype) :: wtype_3d, type_towrite ! , wtype_scalar
     call MPI_COMM_SIZE(MPI_COMM_WORLD,nproc,ierr)
     call read_dnsin()
 
+    !-----------!
+    ! ATTENTION !
+    !-----------!
     ! set npy to total number of processes
     ! this effectively DEACTIVATES PARALLELISATION IN Z
     ! and makes life easier (without significant losses in perf.)
     npy = nproc
     ! notice that this overrides value from dns.in
+    !-----------------------------------------------------------------!
+    ! NEVER RUN THIS PROGRAM WITH X/Z PARALLELISATION (it won't work) !
+    !-----------------------------------------------------------------!
 
     call init_MPI(nx+1,nz,ny,nxd+1,nzd)
     call init_memory(.FALSE.)
-    call init_fft(VVdz,VVdx,rVVdx,nxB,nxB,2*nz+1,2*nz+1)
+    call init_fft(VVdz,VVdx,rVVdx,nxB,nxB,2*nz+1,2*nz+1,.TRUE.)
+    ! LAST FLAG OF init_fft (.TRUE.) SPECIFIES THAT REAL FFT TRANSFORM HAS AN ODD LOGICAL SIZE
     ! Notice that in the call to init_fft the values of nxd and nzd have been replaced by nxB and 2*nz+1.
     ! Since the parallelisation in xz is deactivated, nxB=nx+1.
     ! Instead, nxd and nzd are the expanded number of points that are needed for dealiasing;
@@ -171,8 +178,8 @@ type(MPI_Datatype) :: wtype_3d, type_towrite ! , wtype_scalar
         ! WARNING: this differs from normal program, since there is no extension of the Fourier domain
         ! (or, no increase of spatial resolution to avoid dealiasing)
         ! i.e., no need to set anything zo zero in the arrays
-        VVdz(1:nz+1,1:nxB,1:3,1)=V(iy,0:nz,nx0:nxN,1:3);
-        VVdz(nz+2:2*nz+1,1:nxB,1:3,1)=V(iy,-nz:-1,nx0:nxN,1:3); 
+        VVdz(1:nz+1,:,1:3,1)=V(iy,0:nz,:,1:3);
+        VVdz(nz+2:2*nz+1,:,1:3,1)=V(iy,-nz:-1,:,1:3); 
         do iV=1,3
             call IFT(VVdz(1:2*nz+1,1:nxB,iV,1)) ! first transform in z
             
@@ -187,7 +194,7 @@ type(MPI_Datatype) :: wtype_3d, type_towrite ! , wtype_scalar
             end do
             
             call RFT(VVdx(:,:,iV,1),rVVdx(:,:,iV,1)) ! second transform in x
-            ! TODO FIXME this might actually be rVVdx(1:2*nx+2) but idk
+            
         end do
         ! rVVdx is now containing the antitransform
         ! it has size 2*nx+1,2*nz+1,6,6
@@ -205,9 +212,9 @@ type(MPI_Datatype) :: wtype_3d, type_towrite ! , wtype_scalar
         do iz=1,nztot
             do ix=1,nxtot
                 call undersampled_to_fullindex(ix,iz, xfull_idx,zfull_idx)
-                xyz(1,ix,iy,iz) = (xfull_idx-1) * (2 * PI / alfa0)/(2*nx)
+                xyz(1,ix,iy,iz) = (xfull_idx-1) * (2 * PI / alfa0)/(2*nx+1)
                 xyz(2,ix,iy,iz) = y(iy)
-                xyz(3,ix,iy,iz) = (zfull_idx-1) * (2 * PI / beta0)/(2*nz)
+                xyz(3,ix,iy,iz) = (zfull_idx-1) * (2 * PI / beta0)/(2*nz+1)
             end do
         end do
 
@@ -396,12 +403,16 @@ contains !----------------------------------------------------------------------
     ! whereas xprj=1,2*nx+1 and zprj=1,2*nz+1.
     ! However, xprj and zprj are REAL NUMBERS, meaning that (xx,zz) can correspond to a position that is
     ! inbetween two points of the array rVVdx.
+    ! The logic here is that:
+    ! - xx=1 gets mapped to xprj=1 (as this is x=0 in space, i.e. the first extreme of the periodic domain)
+    ! - xx=nxtot+1 gets mapped to xprj=2*nx+2 (as this would be the other extreme of the periodic domain)
+    ! Same applies for z.
 
     integer, intent(in) :: xx, zz
     real, intent(out) :: xprj,zprj
 
-        xprj = (xx - 1.0) / (nxtot-1.0) * (2*nx) + 1
-        zprj = (zz - 1.0) / (nztot-1.0) * (2*nz) + 1
+        xprj = (2*nx+1)/(nxtot) * (xx - 1.0) + 1
+        zprj = (2*nz+1)/(nztot) * (zz - 1.0) + 1
 
     end subroutine undersampled_to_fullindex
 

--- a/out2vtk.f90
+++ b/out2vtk.f90
@@ -186,7 +186,7 @@ type(MPI_Datatype) :: wtype_3d, type_towrite ! , wtype_scalar
                 end do
             end do
             
-            call RFT(VVdx(1:nx+1,1:2*nz+1,iV,1),rVVdx(1:2*nx+1,1:2*nz+1,iV,1)) ! second transform in x
+            call RFT(VVdx(:,:,iV,1),rVVdx(:,:,iV,1)) ! second transform in x
             ! TODO FIXME this might actually be rVVdx(1:2*nx+2) but idk
         end do
         ! rVVdx is now containing the antitransform


### PR DESCRIPTION
Fixed out2vtk; ffts.f90 is now slightly modified, so that odd logical sizes of the real FT are allowed (through a flag).